### PR TITLE
Nerfs powerator a lot

### DIFF
--- a/modular_skyrat/modules/power/code/powerator.dm
+++ b/modular_skyrat/modules/power/code/powerator.dm
@@ -58,7 +58,7 @@
 	/// the max amount of power that can be sent per process, from 100000 (t1) to 10000000 (t4)
 	var/max_power = 100000
 	/// how much the current_power is divided by to determine the profit
-	var/divide_ratio = 0.00001
+	var/divide_ratio = 0.0000001 // 1e-07 Bubber Edit Nerfing Powerator a lot
 	/// the attached cable to the machine
 	var/obj/structure/cable/attached_cable
 	/// how many credits this machine has actually made so far


### PR DESCRIPTION
## About The Pull Request

Powerator makes a lot of free money from just energy, this makes it a lot worse.

## Why It's Good For The Game

Its too easy to make 100k+ money with it an teg making 20 MW, this nerfs it a lot. 

## Proof Of Testing

Works, its a simple var change nothing serious 

## Changelog

:cl:
balance: Powerator makes too much money, so it was nerfed.
/:cl:
